### PR TITLE
Model Caching

### DIFF
--- a/validator/main.py
+++ b/validator/main.py
@@ -273,64 +273,64 @@ class ProvenanceLLM(Validator):
         If `query_function` is provided, it will be used. Otherwise, `sources` and
         `embed_function` will be used to create a default query function.
         """
-        # query_fn = metadata.get("query_function", None)
+        query_fn = metadata.get("query_function", None)
         sources = metadata.get("sources", None)
 
-        # # Check that query_fn or sources are provided
-        # if query_fn is not None:
-        #     if sources is not None:
-        #         warnings.warn(
-        #             "Both `query_function` and `sources` are provided in metadata. "
-        #             "`query_function` will be used."
-        #         )
-        #     return query_fn
-
-        # if sources is None:
-        #     raise ValueError(
-        #         "You must provide either `query_function` or `sources` in metadata."
-        #     )
-
-        # # Check chunking strategy, size and overlap
-        # chunk_strategy = metadata.get("chunk_strategy", "sentence")
-        # if chunk_strategy not in ["sentence", "word", "char", "token"]:
-        #     raise ValueError(
-        #         "`chunk_strategy` must be one of 'sentence', 'word', "
-        #         "'char', or 'token'."
-        #     )
-        # chunk_size = metadata.get("chunk_size", 5)
-        # chunk_overlap = metadata.get("chunk_overlap", 2)
-
-        # # Check embed model
-        # embed_function = metadata.get("embed_function", None)
-        # if embed_function is None:
-        #     # Load model for embedding function
-        #     MODEL = SentenceTransformer("paraphrase-MiniLM-L6-v2")
-
-        #     # Create embed function
-        #     def st_embed_function(sources: list[str]):
-        #         return MODEL.encode(sources)
-
-        #     embed_function = st_embed_function
-
-        def embed_function(text, model="text-embedding-3-small"):
-            text = text[-1]
-            text = text.replace("\n", " ")
-            result = np.array(
-                (
-                    self.embedding_client.embeddings.create(input=[text], model=model)
-                    .data[0]
-                    .embedding
+        # Check that query_fn or sources are provided
+        if query_fn is not None:
+            if sources is not None:
+                warnings.warn(
+                    "Both `query_function` and `sources` are provided in metadata. "
+                    "`query_function` will be used."
                 )
+            return query_fn
+
+        if sources is None:
+            raise ValueError(
+                "You must provide either `query_function` or `sources` in metadata."
             )
-            return result
+
+        # Check chunking strategy, size and overlap
+        chunk_strategy = metadata.get("chunk_strategy", "sentence")
+        if chunk_strategy not in ["sentence", "word", "char", "token"]:
+            raise ValueError(
+                "`chunk_strategy` must be one of 'sentence', 'word', "
+                "'char', or 'token'."
+            )
+        chunk_size = metadata.get("chunk_size", 5)
+        chunk_overlap = metadata.get("chunk_overlap", 2)
+
+        # Check embed model
+        embed_function = metadata.get("embed_function", None)
+        if embed_function is None:
+            # Load model for embedding function
+            MODEL = SentenceTransformer("paraphrase-MiniLM-L6-v2")
+
+            # Create embed function
+            def st_embed_function(sources: list[str]):
+                return MODEL.encode(sources)
+
+            embed_function = st_embed_function
+
+        # def embed_function(text, model="text-embedding-3-small"):
+        #     text = text[-1]
+        #     text = text.replace("\n", " ")
+        #     result = np.array(
+        #         (
+        #             self.embedding_client.embeddings.create(input=[text], model=model)
+        #             .data[0]
+        #             .embedding
+        #         )
+        #     )
+        #     return result
 
         return partial(
             self.query_vector_collection,
             sources=metadata["sources"],
             embed_function=embed_function,
-            chunk_strategy="sentence",
-            chunk_size=5,
-            chunk_overlap=2,
+            chunk_strategy=chunk_strategy,
+            chunk_size=chunk_size,
+            chunk_overlap=chunk_overlap,
         )
 
     @staticmethod
@@ -359,7 +359,7 @@ class ProvenanceLLM(Validator):
         cos_sim = 1 - (
             np.dot(source_embeddings, query_embedding)
             / (
-                np.linalg.norm(source_embeddings, axis=0)
+                np.linalg.norm(source_embeddings, axis=1)
                 * np.linalg.norm(query_embedding)
             )
         )

--- a/validator/main.py
+++ b/validator/main.py
@@ -304,7 +304,7 @@ class ProvenanceLLM(Validator):
         embed_function = metadata.get("embed_function", None)
         if embed_function is None:
             # Load model for embedding function
-            MODEL = SentenceTransformer("paraphrase-MiniLM-L6-v2")
+            MODEL = SentenceTransformer("./models/sentence-transformers/paraphrase-MiniLM-L6-v2")
 
             # Create embed function
             def st_embed_function(sources: list[str]):

--- a/validator/main.py
+++ b/validator/main.py
@@ -304,10 +304,12 @@ class ProvenanceLLM(Validator):
         embed_function = metadata.get("embed_function", None)
         if embed_function is None:
             # Load model for embedding function
+            print("Loading embedding model from ./models/sentence-transformers/paraphrase-MiniLM-L6-v2...")
             MODEL = SentenceTransformer("./models/sentence-transformers/paraphrase-MiniLM-L6-v2")
 
             # Create embed function
             def st_embed_function(sources: list[str]):
+                print("Running st_embed_function...")
                 return MODEL.encode(sources)
 
             embed_function = st_embed_function

--- a/validator/post-install.py
+++ b/validator/post-install.py
@@ -10,4 +10,4 @@ print("NLTK stuff loaded successfully.")
 
 # Load model for default embedding function
 model = SentenceTransformer("paraphrase-MiniLM-L6-v2")
-model.save('/models/sentence-transformers/paraphrase-MiniLM-L6-v2')
+model.save('/opt/models/sentence-transformers/paraphrase-MiniLM-L6-v2')

--- a/validator/post-install.py
+++ b/validator/post-install.py
@@ -9,4 +9,5 @@ except LookupError:
 print("NLTK stuff loaded successfully.")
 
 # Load model for default embedding function
-SentenceTransformer("paraphrase-MiniLM-L6-v2")
+model = SentenceTransformer("paraphrase-MiniLM-L6-v2")
+model.save()

--- a/validator/post-install.py
+++ b/validator/post-install.py
@@ -10,4 +10,4 @@ print("NLTK stuff loaded successfully.")
 
 # Load model for default embedding function
 model = SentenceTransformer("paraphrase-MiniLM-L6-v2")
-model.save()
+model.save('models')

--- a/validator/post-install.py
+++ b/validator/post-install.py
@@ -10,4 +10,4 @@ print("NLTK stuff loaded successfully.")
 
 # Load model for default embedding function
 model = SentenceTransformer("paraphrase-MiniLM-L6-v2")
-model.save('/opt/models/sentence-transformers/paraphrase-MiniLM-L6-v2')
+model.save('/.cache/models/sentence-transformers/paraphrase-MiniLM-L6-v2')

--- a/validator/post-install.py
+++ b/validator/post-install.py
@@ -10,4 +10,4 @@ print("NLTK stuff loaded successfully.")
 
 # Load model for default embedding function
 model = SentenceTransformer("paraphrase-MiniLM-L6-v2")
-model.save('/.cache/models/sentence-transformers/paraphrase-MiniLM-L6-v2')
+model.save('./models/sentence-transformers/paraphrase-MiniLM-L6-v2')

--- a/validator/post-install.py
+++ b/validator/post-install.py
@@ -10,4 +10,4 @@ print("NLTK stuff loaded successfully.")
 
 # Load model for default embedding function
 model = SentenceTransformer("paraphrase-MiniLM-L6-v2")
-model.save('models')
+model.save('/models/sentence-transformers/paraphrase-MiniLM-L6-v2')


### PR DESCRIPTION
This PR demonstrates how we can properly cache local models during post-install for quick recall in a containerized environment (i.e. docker).

Currently it saves to a relative directory in the root of wherever the validator is installed which isn't ideal.  We will need to figure out what directories we can use both locally and in a docker environment that will not require additional permissions (the reason we're not writing to something like `.cache`).


Beside caching the model weights for quick retrieval, we also introduce a singleton pattern for initializing the instance of the model.  


In order to test and demonstrate the above, we switch the default encoding function back to the sentence-transformer model. 